### PR TITLE
Add dyno name to the hostname.

### DIFF
--- a/extra/run-dogstatsd.sh
+++ b/extra/run-dogstatsd.sh
@@ -8,7 +8,7 @@ else
 fi
 
 if [[ $HEROKU_APP_NAME ]]; then
-  sed -i -e "s/^.*hostname:.*$/hostname: ${HEROKU_APP_NAME}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
+  sed -i -e "s/^.*hostname:.*$/hostname: ${HEROKU_APP_NAME}-${DYNO}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
 else
   echo "HEROKU_APP_NAME environment variable not set. Run: heroku apps:info|grep ===|cut -d' ' -f2"
   exit 1


### PR DESCRIPTION
This makes the dyno name semi unique and fixes the issue where
counts from multiple hosts are treated as the same host and
normalized by datadog